### PR TITLE
verifyPaymentSignature fix

### DIFF
--- a/razorpay/utility/utility.py
+++ b/razorpay/utility/utility.py
@@ -29,5 +29,3 @@ class Utility(object):
 
         if not hmac.compare_digest(generated_signature, razorpay_signature):
             raise SignatureVerificationError('Payment Signature Verification Failed')
-
-        return True

--- a/tests/test_client_utility.py
+++ b/tests/test_client_utility.py
@@ -17,9 +17,8 @@ class TestClientValidator(ClientTestCase):
         parameters['razorpay_payment_id'] = 'fake_payment_id'
         parameters['razorpay_signature'] = sig
 
-        self.assertEqual(
-            self.client.utility.verify_payment_signature(parameters),
-            True)
+        self.client.utility.verify_payment_signature(parameters)
+        self.assert_(True)
 
     @responses.activate
     def test_verify_payment_signature_with_exception(self):
@@ -27,6 +26,7 @@ class TestClientValidator(ClientTestCase):
         parameters['razorpay_order_id'] = 'fake_order_id'
         parameters['razorpay_payment_id'] = 'fake_payment_id'
         parameters['razorpay_signature'] = 'test_signature'
+
         self.assertRaises(
             SignatureVerificationError,
             self.client.utility.verify_payment_signature,

--- a/tests/test_client_utility.py
+++ b/tests/test_client_utility.py
@@ -17,8 +17,9 @@ class TestClientValidator(ClientTestCase):
         parameters['razorpay_payment_id'] = 'fake_payment_id'
         parameters['razorpay_signature'] = sig
 
-        self.client.utility.verify_payment_signature(parameters)
-        self.assert_(True)
+        self.assertEqual(
+             self.client.utility.verify_payment_signature(parameters),
+             None)
 
     @responses.activate
     def test_verify_payment_signature_with_exception(self):


### PR DESCRIPTION
Throws exception when signature verification fails but returns nothing