### PR TITLE
[utility] Changes method signature to match other SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ that both app title and version are strings.
     `webhook_signature` is the signature you receive under `X-Razorpay-Header` in the webhook, while `webhook_secret` is the secret you used when creating the webhook on dashboard.
 
     ```py
-    client.utility.verify_webhook_signature(webhook_signature, webhook_body, webhook_secret)
+    client.utility.verify_webhook_signature(webhook_body, webhook_signature, webhook_secret)
     ```
 
 ## Bugs? Feature requests? Pull requests?

--- a/razorpay/utility/utility.py
+++ b/razorpay/utility/utility.py
@@ -19,12 +19,12 @@ class Utility(object):
 
         secret = str(self.client.auth[1])
 
-        self.verify_signature(razorpay_signature, msg, secret)
+        self.verify_signature(msg, razorpay_signature, secret)
 
-    def verify_webhook_signature(self, signature, body, secret):
-        self.verify_signature(signature, body, secret)
+    def verify_webhook_signature(self, body, signature, secret):
+        self.verify_signature(body, signature, secret)
 
-    def verify_signature(self, signature, body, key):
+    def verify_signature(self, body, signature, key):
         if sys.version_info[0] == 3:  # pragma: no cover
             key = bytes(key, 'utf-8')
             body = bytes(body, 'utf-8')

--- a/tests/test_client_utility.py
+++ b/tests/test_client_utility.py
@@ -40,7 +40,7 @@ class TestClientValidator(ClientTestCase):
         body = mock_file('fake_payment_authorized_webhook')
 
         self.assertEqual(
-             self.client.utility.verify_webhook_signature(sig, body, secret),
+             self.client.utility.verify_webhook_signature(body, sig, secret),
              None)
 
     @responses.activate
@@ -52,6 +52,6 @@ class TestClientValidator(ClientTestCase):
         self.assertRaises(
             SignatureVerificationError,
             self.client.utility.verify_webhook_signature,
-            sig,
             body,
+            sig,
             secret)


### PR DESCRIPTION
PHP, Java, and .NET follow `body-signature-secret`, while Ruby and Python were following `signature-body-secret`. With the recent bugfix (#25), we have a chance to fix and make this consistent without requiring a major release.