### PR TITLE
Returning result in verify_signature

### DIFF
--- a/razorpay/utility/utility.py
+++ b/razorpay/utility/utility.py
@@ -19,10 +19,10 @@ class Utility(object):
 
         secret = str(self.client.auth[1])
 
-        self.verify_signature(msg, razorpay_signature, secret)
+        return self.verify_signature(msg, razorpay_signature, secret)
 
     def verify_webhook_signature(self, body, signature, secret):
-        self.verify_signature(body, signature, secret)
+        return self.verify_signature(body, signature, secret)
 
     def verify_signature(self, body, signature, key):
         if sys.version_info[0] == 3:  # pragma: no cover
@@ -43,6 +43,7 @@ class Utility(object):
         if not result:
             raise SignatureVerificationError(
                 'Razorpay Signature Verification Failed')
+        return result
 
     # Taken from Django Source Code
     # Used in python version < 2.7.7

--- a/tests/test_client_utility.py
+++ b/tests/test_client_utility.py
@@ -19,7 +19,7 @@ class TestClientValidator(ClientTestCase):
 
         self.assertEqual(
              self.client.utility.verify_payment_signature(parameters),
-             None)
+             True)
 
     @responses.activate
     def test_verify_payment_signature_with_exception(self):
@@ -41,7 +41,7 @@ class TestClientValidator(ClientTestCase):
 
         self.assertEqual(
              self.client.utility.verify_webhook_signature(body, sig, secret),
-             None)
+             True)
 
     @responses.activate
     def test_verify_webhook_signature_with_exception(self):


### PR DESCRIPTION
I was trying to integrate razorpay webhooks on my website but the `verify_signature` method does not return anything if the signature is valid. we only get error when its invalid. so i have added some changes to return the result if its valid. Moreover I think we should return only the result `(TRUE/FALSE)` in `verify_signature` method not an error.

ref: #54