### PR TITLE
Documentation for PyPI page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
 from setuptools import setup
 
+with open('README.md') as readme:
+    readme_content = readme.read()
+
 setup(
     name="razorpay",
     version="1.2.0",
     description="Razorpay Python Client",
+    long_description=readme_content,
+    long_description_content_type='text/markdown',
     url="https://github.com/razorpay/razorpay-python",
     author="Team Razorpay",
     license="MIT",


### PR DESCRIPTION
Fixes #90 

- Used `text/markdown` as [Description-Content-Type](https://packaging.python.org/specifications/core-metadata/#description-content-type)

### Result of testing validation of markup
Ran `twine check dist/*`
**Results**:
```
Checking dist/razorpay-1.2.0-py3-none-any.whl: PASSED
Checking dist/razorpay-1.2.0.tar.gz: PASSED
```