### PR TITLE
Use 'with' keyword while opening file in tests/helpers.py

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,7 +8,9 @@ def mock_file(filename):
         return ''
     file_dir = os.path.dirname(__file__)
     file_path = "{}/mocks/{}.json".format(file_dir, filename)
-    return open(file_path).read()
+    with open(file_path) as f:
+        mock_file_data = f.read()
+    return mock_file_data
 
 
 class ClientTestCase(unittest.TestCase):


### PR DESCRIPTION
Fixes #98 

- Used [`with`](https://docs.python.org/3.8/reference/compound_stmts.html#with) keyword while opening file.
> It is good practice to use the `with` keyword when dealing with file objects. The advantage is that the file is properly closed after its suite finishes, even if an exception is raised at some point.

Python Docs: [Reading and Writing Files](https://docs.python.org/3.8/tutorial/inputoutput.html#reading-and-writing-files)