### PR TITLE
Fix Issues with signature verification

### DIFF
--- a/razorpay/errors.py
+++ b/razorpay/errors.py
@@ -11,8 +11,3 @@ class GatewayError(Exception):
 class ServerError(Exception):
     def __init__(self, message=None, *args, **kwargs):
         super(ServerError, self).__init__(message)
-
-
-class SignatureVerificationError(Exception):
-    def __init__(self, message=None, *args, **kwargs):
-        super(SignatureVerificationError, self).__init__(message)

--- a/razorpay/utility/utility.py
+++ b/razorpay/utility/utility.py
@@ -3,9 +3,6 @@ import hashlib
 import sys
 
 
-from ..errors import SignatureVerificationError
-
-
 class Utility(object):
     def __init__(self, client=None):
         self.client = client
@@ -40,9 +37,7 @@ class Utility(object):
         else:
             result = hmac.compare_digest(generated_signature, signature)
 
-        if not result:
-            raise SignatureVerificationError(
-                'Razorpay Signature Verification Failed')
+        # returns True if verified else returns False
         return result
 
     # Taken from Django Source Code

--- a/tests/test_client_utility.py
+++ b/tests/test_client_utility.py
@@ -1,7 +1,6 @@
 import responses
 
 from .helpers import mock_file, ClientTestCase
-from razorpay.errors import SignatureVerificationError
 
 
 class TestClientValidator(ClientTestCase):
@@ -28,10 +27,9 @@ class TestClientValidator(ClientTestCase):
         parameters['razorpay_payment_id'] = 'fake_payment_id'
         parameters['razorpay_signature'] = 'test_signature'
 
-        self.assertRaises(
-            SignatureVerificationError,
-            self.client.utility.verify_payment_signature,
-            parameters)
+        result = self.client.utility.verify_payment_signature(parameters)
+
+        self.assertFalse(result)
 
     @responses.activate
     def test_verify_webhook_signature(self):
@@ -49,9 +47,8 @@ class TestClientValidator(ClientTestCase):
         sig = 'test_signature'
         body = ''
 
-        self.assertRaises(
-            SignatureVerificationError,
-            self.client.utility.verify_webhook_signature,
-            body,
-            sig,
-            secret)
+        result = self.client.utility.verify_webhook_signature(
+            body, sig, secret
+        )
+
+        self.assertFalse(result)


### PR DESCRIPTION
closes https://github.com/razorpay/razorpay-python/issues/106

The ``verify_signature`` function should return ``True`` or ``False`` it should not return a ``True`` or ``Exception``

this PR removes the confusion with the ``verify_signature`` 

By making it only boolean it will make it easy for users to check if the verification succeeded or failed with just a condition.