### PR TITLE
Fix TypeError while validating webhook signature(Fix #121)

### DIFF
--- a/razorpay/utility/utility.py
+++ b/razorpay/utility/utility.py
@@ -25,9 +25,12 @@ class Utility(object):
         return self.verify_signature(body, signature, secret)
 
     def verify_signature(self, body, signature, key):
-        if sys.version_info[0] == 3:  # pragma: no cover
-            key = bytes(key, 'utf-8')
-            body = bytes(body, 'utf-8')
+        if sys.version_info[0] == 3:
+            # ensure if not already bytes object
+            if not isinstance(key, (bytes, bytearray)):
+                key = bytes(key, 'utf-8')
+            if not isinstance(body, (bytes, bytearray)):
+                body = bytes(body, 'utf-8')
 
         dig = hmac.new(key=key,
                        msg=body,

--- a/tests/test_client_utility.py
+++ b/tests/test_client_utility.py
@@ -44,6 +44,16 @@ class TestClientValidator(ClientTestCase):
              True)
 
     @responses.activate
+    def test_verify_webhook_signature_with_bytes_data(self):
+        secret = self.client.auth[1]
+        sig = 'd60e67fd884556c045e9be7dad57903e33efc7172c17c6e3ef77db42d2b366e9'
+        body = bytes(mock_file('fake_payment_authorized_webhook'), 'utf-8')
+
+        self.assertEqual(
+             self.client.utility.verify_webhook_signature(body, sig, secret),
+             True)
+
+    @responses.activate
     def test_verify_webhook_signature_with_exception(self):
         secret = self.client.auth[1]
         sig = 'test_signature'


### PR DESCRIPTION
I have fixed issue #121 created by @niketnishi.

What was the issue I tried to fix -

- When razorpay send a post request for a particular webhook then it send the body as raw which we get as bytes object already. which I observed in Flask and Django, I am not sure about other frameworks.
- So when we pass the body to `verify_webhook_signature` the it parse the body to bytes object first which if already a bytes like object raises a `TypeError`.

Changes made -

- Add a check for bytes object of `key` and `body` before making the digest signature.
- Add a test for above implementation.