### PR TITLE
Edit Subscription function name change

### DIFF
--- a/razorpay/resources/subscription.py
+++ b/razorpay/resources/subscription.py
@@ -80,7 +80,7 @@ class Subscription(Resource):
         url = "{}/{}/addons".format(self.base_url, subscription_id)
         return self.post_url(url, data, **kwargs) 
 
-    def edit(self, subscription_id, data={}, **kwargs):
+    def update(self, subscription_id, data={}, **kwargs):
         """"
          Update particular subscription
 


### PR DESCRIPTION
Razorpay documentation states that the subscription should be updated - 
client.subscription.update(subscriptionId, options)

Reference - https://razorpay.com/docs/api/payments/subscriptions/#update-a-subscription

So Edit subscription Function should be named to update

Related Issue - https://github.com/razorpay/razorpay-python/issues/224
