### PR TITLE
Fix: Added decimal encoder

### DIFF
--- a/razorpay/client.py
+++ b/razorpay/client.py
@@ -7,6 +7,7 @@ from pkg_resources import DistributionNotFound
 
 from types import ModuleType
 
+from razorpay.resources.base import DecimalEncoder
 from .constants import HTTP_STATUS_CODE, ERROR_CODE, URL
 
 from . import resources, utility
@@ -180,7 +181,7 @@ class Client:
         """
         Updates The resource data and header options
         """
-        data = json.dumps(data)
+        data = json.dumps(data, cls=DecimalEncoder)
 
         if 'headers' not in options:
             options['headers'] = {}

--- a/razorpay/resources/base.py
+++ b/razorpay/resources/base.py
@@ -1,3 +1,6 @@
+from decimal import Decimal
+from json import JSONEncoder
+
 class Resource(object):
 
     def __init__(self, client=None):
@@ -28,3 +31,12 @@ class Resource(object):
     def delete(self, id, data, **kwargs):
         url = "{}/{}/delete".format(self.base_url, id)
         return self.delete_url(url, data, **kwargs)
+
+class DecimalEncoder(JSONEncoder):
+    def default(self, obj):
+        # if passed in object is instance of Decimal
+        # convert it to a string
+        if isinstance(obj, Decimal):
+            return str(obj)
+        # 👇️ otherwise use the default behavior
+        return JSONEncoder.default(self, obj)


### PR DESCRIPTION
Explanation of the Issue I had given a fix for.

Hi team,

There was an unhandled exception on the client SDK, that if a `Decimal` type is passed as an amount while creating order it raised the following error, `TypeError: Object of type Decimal is not JSON serializable`

```
File "/home/ubuntu/.local/share/virtualenvs/tortoise-customer-webserver-x9341mt2/lib/python3.7/site-packages/razorpay/client.py", line 183, in _update_request
    data = json.dumps(data)
  File "/home/ubuntu/.pyenv/versions/3.7.13/lib/python3.7/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/home/ubuntu/.pyenv/versions/3.7.13/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/home/ubuntu/.pyenv/versions/3.7.13/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/home/ubuntu/.pyenv/versions/3.7.13/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
```

This will be common for Django environment, as I had previously came across the same issue with some other package, thereby contributing a fix. However, the Razorpay backend would anyway return a 400 error stating that `the amount should be int`. 