### PR TITLE
header issue fixed

### DIFF
--- a/razorpay/client.py
+++ b/razorpay/client.py
@@ -53,6 +53,8 @@ class Client:
 
         self.app_details = []
 
+        self.app_headers = {}
+
         # intializes each resource
         # injecting this client object into the constructor
         for name, Klass in RESOURCE_CLASSES.items():
@@ -106,13 +108,16 @@ class Client:
     def set_app_details(self, app_details):
         self.app_details.append(app_details)
 
+    def set_app_headers(self, app_headers):
+        self.app_headers = app_headers
+
     def get_app_details(self):
         return self.app_details
 
     def request(self, method, path, **options):
         """
         Dispatches a request to the Razorpay HTTP API
-        """
+        """        
         options = self._update_user_agent_header(options)
 
         url = "{}{}".format(self.base_url, path)
@@ -181,10 +186,13 @@ class Client:
         Updates The resource data and header options
         """
         data = json.dumps(data)
-
+        
         if 'headers' not in options:
             options['headers'] = {}
 
         options['headers'].update({'Content-type': 'application/json'})
+
+        if 'headers' in self.app_headers:
+         options['headers'].update(self.app_headers['headers'])
 
         return data, options


### PR DESCRIPTION
Now we can add `X-Razorpay-Account` or `X-Transfer-Idempotency` in the header

https://razorpay.com/docs/api/x/payout-idempotency/

https://razorpay.com/docs/api/payments/route/#fetch-payments-of-a-linked-account