### PR TITLE
Fix python matrix on GitHub Actions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,12 +17,14 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
+      with:
+          python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Currently, the Action doesn't use the matrix correctly. This leads to the default python version of 3.10.7 being installed every time.

Use the `python-version` variable during the installation step to pick up the correct value from the matrix. Making this change also reveals specifying "3.10" as Integer tries to install Python 3.1, which doesn't exist.

Hence specify the versions as String.