### PR TITLE
Fix python matrix on GitHub Actions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest # nosemgrep : semgrep.dev/s/swati31196:github_provided_runner
+    runs-on: ubuntu-20.04 # nosemgrep : semgrep.dev/s/swati31196:github_provided_runner
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,12 +17,14 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
+      with:
+          python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.0.1", "3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.18", "3.10.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.0.1", "3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.18", "3.10.0"]
+        python-version: ["3.5.10", "3.6.15", "3.7.17", "3.8.18", "3.9.18", "3.10.0"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
1. Currently, the Action doesn't use the matrix correctly. This leads to the default python version of 3.11.5 being installed every time. You can see that at https://github.com/SubhrajyotiSen/razorpay-python/actions/runs/6550129767/job/17788570158 
Use the `python-version` variable during the installation step to pick up the correct value from the matrix. Making this change also reveals specifying "3.10" as Integer tries to install Python 3.1, which doesn't exist.
Hence specify the versions as String.

2. As per https://github.com/actions/setup-python/issues/544, `ubuntu-latest` doesn't have all the needed Python version. Hence we need to specify Ubuntu 20.04

3. https://github.com/actions/python-versions/blob/main/versions-manifest.json specifies the Python versions available. According to it, Python 3.0.x is not available on Ubuntu. Hence remove it. I can add support for it by introducing a windows runner

