### PR TITLE
refactor: rename subscription edit method to update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ target/
 
 .DS_Store
 .idea
+venv

--- a/razorpay/resources/subscription.py
+++ b/razorpay/resources/subscription.py
@@ -80,7 +80,7 @@ class Subscription(Resource):
         url = "{}/{}/addons".format(self.base_url, subscription_id)
         return self.post_url(url, data, **kwargs) 
 
-    def edit(self, subscription_id, data={}, **kwargs):
+    def update(self, subscription_id, data={}, **kwargs):
         """
          Update particular subscription
 

--- a/tests/test_client_subscription.py
+++ b/tests/test_client_subscription.py
@@ -81,7 +81,7 @@ class TestClientSubscription(ClientTestCase):
         self.assertEqual(response['item']['amount'], 30000)
 
     @responses.activate
-    def test_subscription_edit(self):
+    def test_subscription_update(self):
         param = {
                  "quantity":2,
                  "schedule_change_at":"cycle_end",
@@ -91,7 +91,7 @@ class TestClientSubscription(ClientTestCase):
         url = '{}/{}'.format(self.base_url, 'subscription_id')
         responses.add(responses.PATCH, url, status=200, body=json.dumps(result),
                       match_querystring=True)
-        self.assertEqual(self.client.subscription.edit('subscription_id', param), result)     
+        self.assertEqual(self.client.subscription.update('subscription_id', param), result)     
 
     @responses.activate
     def test_subscription_pending_update(self):


### PR DESCRIPTION
PR introduces below change on `subscription` instance:
`edit` → `update`

closes #224, #282

Fixes the mismatched naming of update method between website doc and implementation.