### PR TITLE
Fix : Removed Overwritten refund Method Definition

### DIFF
--- a/razorpay/resources/payment.py
+++ b/razorpay/resources/payment.py
@@ -49,21 +49,6 @@ class Payment(Resource):
         data['amount'] = amount
         return self.post_url(url, data, **kwargs)
 
-    def refund(self, payment_id, amount, data={}, **kwargs):  # pragma: no cover # nosemgrep : python.lang.correctness.common-mistakes.default-mutable-dict.default-mutable-dict
-        """
-        Refund Payment for given Id
-
-        Args:
-            payment_id : Id for which payment object has to be refunded
-            amount : Amount for which the payment has to be refunded
-
-        Returns:
-            Payment dict after getting refunded
-        """
-        url = "{}/{}/refund".format(self.base_url, payment_id)
-        data['amount'] = amount
-        return self.post_url(url, data, **kwargs)
-
     def transfer(self, payment_id, data={}, **kwargs):
         """
         Create Transfer for given Payment Id


### PR DESCRIPTION
Fixes #289 

This pull request removes the first `refund` method definition from the class, as it was being overwritten by the second definition. Since Python does not support function overloading, the first method was redundant and unused.  

**Changes Made:**  
- Removed the `refund` method with the `amount` parameter.  

**Reason for Change:**  
The first definition was being overwritten, causing the logic for handling refunds with the `amount` parameter to be lost. Removing the redundant definition simplifies the code and eliminates potential confusion.  

**Impact:**  
This change ensures that the remaining `refund` method is the sole implementation, avoiding ambiguity in the codebase.  