### PR TITLE
Added request retry mechanism

### DIFF
--- a/razorpay/client.py
+++ b/razorpay/client.py
@@ -2,6 +2,8 @@ import os
 import json
 import requests
 import warnings
+import random
+import time
 
 from types import ModuleType
 


### PR DESCRIPTION
### Fix intermittent connection issue

- In the latest changes, the SDK handles `ConnectionError` exceptions at the application layer, which ensures retries even when there’s no response from the server.

intermittent connection issue 
```
Exception :   ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response')) 
```


1. Enable/Disable:
      - Retry mechanism is disabled by default
      - Can be enabled with client.enable_retry(True)
2. If enabled:
     a. Number of times to retry:
         Default: 5 retries (defined in DEFAULTS['max_retries'])
         Configurable via constructor parameter
   ```      
   client = razorpay.Client(auth=("key_id", "key_secret"), max_retries=3)
   ```
     b. Time period between retries / logic for exponential backoff:
         Uses exponential backoff with jitter
         Default parameters:
              Initial delay: 1 second
              Max delay cap: 60 seconds
         Formula: Each retry doubles the previous delay (delay_seconds *= 2), with added random jitter.
         Jitter is calculated as:  `jitter_value = random.uniform(-self.jitter, self.jitter)`
         Final delay is: `delay_seconds * (1 + jitter_value)`, capped at max_delay
     c. Specific conditions to retry on:
           retries on:
            `requests.exceptions.ConnectionError` : Network connectivity issues
            `requests.exceptions.Timeout` : Request timeout errors
            does NOT retry on:
            `requests.exceptions.RequestException` : Other request exceptions (edited)
