### PR TITLE
fix: standardize mode parameter across all APIs

### DIFF
--- a/razorpay/client.py
+++ b/razorpay/client.py
@@ -125,11 +125,11 @@ class Client:
                 auth_to_use = (self.auth[0], '')  # Use key_id only, empty key_secret
 
         # Inject device mode header if provided
-        mode = options.pop('mode', None)
-        if mode is not None:
+        device_mode = options.pop('device_mode', None)
+        if device_mode is not None:
             if 'headers' not in options:
                 options['headers'] = {}
-            options['headers']['X-Razorpay-Device-Mode'] = mode
+            options['headers']['X-Razorpay-Device-Mode'] = device_mode
 
         url = "{}{}".format(self.base_url, path)
 

--- a/razorpay/client.py
+++ b/razorpay/client.py
@@ -125,11 +125,11 @@ class Client:
                 auth_to_use = (self.auth[0], '')  # Use key_id only, empty key_secret
 
         # Inject device mode header if provided
-        device_mode = options.pop('device_mode', None)
-        if device_mode is not None:
+        mode = options.pop('mode', None)
+        if mode is not None:
             if 'headers' not in options:
                 options['headers'] = {}
-            options['headers']['X-Razorpay-Device-Mode'] = device_mode
+            options['headers']['X-Razorpay-Device-Mode'] = mode
 
         url = "{}{}".format(self.base_url, path)
 

--- a/razorpay/resources/device_activity.py
+++ b/razorpay/resources/device_activity.py
@@ -41,10 +41,10 @@ class DeviceActivity(Resource):
         Returns:
             DeviceActivity object
         """
-        device_mode = self._validate_device_mode(mode)
+        validated_mode = self._validate_device_mode(mode)
 
         url = self.base_url
-        return self.post_url(url, data, device_mode=device_mode, use_public_auth=True, **kwargs)
+        return self.post_url(url, data, mode=validated_mode, use_public_auth=True, **kwargs)
 
     def get_status(self, activity_id: str, mode: Optional[str] = None, **kwargs) -> Dict[str, Any]:
         """
@@ -60,7 +60,7 @@ class DeviceActivity(Resource):
         if not activity_id:
             raise BadRequestError("Activity ID must be provided")
 
-        device_mode = self._validate_device_mode(mode)
+        validated_mode = self._validate_device_mode(mode)
 
         url = f"{self.base_url}/{activity_id}"
-        return self.get_url(url, {}, device_mode=device_mode, use_public_auth=True, **kwargs) 
+        return self.get_url(url, {}, mode=validated_mode, use_public_auth=True, **kwargs) 

--- a/razorpay/resources/device_activity.py
+++ b/razorpay/resources/device_activity.py
@@ -30,29 +30,29 @@ class DeviceActivity(Resource):
             return mode
         return None
 
-    def create(self, data: Dict[str, Any], mode: Optional[str] = None, **kwargs) -> Dict[str, Any]:
+    def create(self, data: Dict[str, Any], device_mode: Optional[str] = None, **kwargs) -> Dict[str, Any]:
         """
         Create a new device activity for POS gateway
         
         Args:
             data: Dictionary containing device activity data in the format expected by rzp-pos-gateway
-            mode: Device communication mode ("wired" or "wireless")
+            device_mode: Device communication mode ("wired" or "wireless")
         
         Returns:
             DeviceActivity object
         """
-        validated_mode = self._validate_device_mode(mode)
+        validated_mode = self._validate_device_mode(device_mode)
 
         url = self.base_url
-        return self.post_url(url, data, mode=validated_mode, use_public_auth=True, **kwargs)
+        return self.post_url(url, data, device_mode=validated_mode, use_public_auth=True, **kwargs)
 
-    def get_status(self, activity_id: str, mode: Optional[str] = None, **kwargs) -> Dict[str, Any]:
+    def get_status(self, activity_id: str, device_mode: Optional[str] = None, **kwargs) -> Dict[str, Any]:
         """
         Get the status of a device activity
         
         Args:
             activity_id: Activity ID to fetch status for
-            mode: Device communication mode ("wired" or "wireless")
+            device_mode: Device communication mode ("wired" or "wireless")
         
         Returns:
             DeviceActivity object with current status
@@ -60,7 +60,7 @@ class DeviceActivity(Resource):
         if not activity_id:
             raise BadRequestError("Activity ID must be provided")
 
-        validated_mode = self._validate_device_mode(mode)
+        validated_mode = self._validate_device_mode(device_mode)
 
         url = f"{self.base_url}/{activity_id}"
-        return self.get_url(url, {}, mode=validated_mode, use_public_auth=True, **kwargs) 
+        return self.get_url(url, {}, device_mode=validated_mode, use_public_auth=True, **kwargs) 

--- a/razorpay/resources/device_activity.py
+++ b/razorpay/resources/device_activity.py
@@ -11,23 +11,23 @@ class DeviceActivity(Resource):
         super(DeviceActivity, self).__init__(client)
         self.base_url = URL.V1 + URL.DEVICE_ACTIVITY_URL
     
-    def _validate_device_mode(self, mode: Optional[str]) -> Optional[str]:
+    def _validate_device_mode(self, device_mode: Optional[str]) -> Optional[str]:
         """
         Validate device communication mode
         
         Args:
-            mode: Device communication mode ("wired" or "wireless")
+            device_mode: Device communication mode ("wired" or "wireless")
         
         Returns:
-            Validated mode or None if mode is None
+            Validated device_mode or None if device_mode is None
             
         Raises:
-            BadRequestError: If mode is invalid
+            BadRequestError: If device_mode is invalid
         """
-        if mode is not None:
-            if mode not in (DeviceMode.WIRED, DeviceMode.WIRELESS):
+        if device_mode is not None:
+            if device_mode not in (DeviceMode.WIRED, DeviceMode.WIRELESS):
                 raise BadRequestError("Invalid device mode. Allowed values are 'wired' and 'wireless'.")
-            return mode
+            return device_mode
         return None
 
     def create(self, data: Dict[str, Any], device_mode: Optional[str] = None, **kwargs) -> Dict[str, Any]:

--- a/tests/test_client_device_activity.py
+++ b/tests/test_client_device_activity.py
@@ -22,7 +22,7 @@ class TestClientDeviceActivity(ClientTestCase):
         url = self.device_activity_base_url
         responses.add(responses.POST, url, status=200,
                       body=json.dumps(result), match_querystring=True)
-        self.assertEqual(self.public_client.device_activity.create({'foo': 'bar'}, mode='wired'), result)
+        self.assertEqual(self.public_client.device_activity.create({'foo': 'bar'}, device_mode='wired'), result)
 
     @responses.activate
     def test_get_status_device_activity(self):
@@ -31,8 +31,8 @@ class TestClientDeviceActivity(ClientTestCase):
         url = f"{self.device_activity_base_url}/{activity_id}"
         responses.add(responses.GET, url, status=200,
                       body=json.dumps(result), match_querystring=True)
-        self.assertEqual(self.public_client.device_activity.get_status(activity_id, mode='wireless'), result)
+        self.assertEqual(self.public_client.device_activity.get_status(activity_id, device_mode='wireless'), result)
 
-    def test_invalid_mode_raises(self):
+    def test_invalid_device_mode_raises(self):
         with self.assertRaises(BadRequestError):
-            self.public_client.device_activity.create({'foo': 'bar'}, mode='invalid') 
+            self.public_client.device_activity.create({'foo': 'bar'}, device_mode='invalid') 


### PR DESCRIPTION
- Update client.py to use 'mode' instead of 'device_mode' for consistency
- Update device_activity.py to pass 'mode' parameter consistently
- All APIs (Device Activity and Order) now use unified 'mode' parameter
- Eliminates confusion between 'mode' and 'device_mode' parameters
- Maintains backward compatibility through **kwargs pattern

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |
