### PR TITLE
fix: alias subscription.edit to subscription.update to match docs

### DIFF
--- a/razorpay/resources/subscription.py
+++ b/razorpay/resources/subscription.py
@@ -85,7 +85,7 @@ class Subscription(Resource):
          Update particular subscription
 
         Args:
-            subscription_id : Id for which subscription has to be edited         
+            subscription_id : Id for which subscription has to be edited        
         Returns:
             Subscription dict for given subscription id
         """
@@ -143,4 +143,7 @@ class Subscription(Resource):
             Subscription Dict for given subscription id
         """
         url = "{}/{}/{}".format(self.base_url, subscription_id, offer_id)
-        return self.delete_url(url, data, **kwargs)                 
+        return self.delete_url(url, data, **kwargs)
+
+    # Alias update to edit to match documentation (Fixes Issue #282)
+    update = edit


### PR DESCRIPTION
### Description
Resolves #282 and #224.

The official Razorpay documentation refers to `subscription.update()`, but the Python SDK only implemented `subscription.edit()`. This caused `AttributeError` for developers following the docs.

### Changes
- Added an alias `update = edit` in `Subscription` class.
- Preserved `edit()` for backward compatibility.

### Verification
- Verified locally that `subscription.update` calls `subscription.edit` correctly.