### PR TITLE
bump version 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+## [2.0.1][2.0.1] - 2026-03-09
+feat: Added Support for cancel token
+
 ## [2.0.0][2.0.0] - 2025-09-22
 fix: pkg_resources deprecation warning on runtime
 feat: Added retry mechanism for failed API calls with `enable_retry(True)` method

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as readme:
 
 setup(
     name="razorpay",
-    version="2.0.0",
+    version="2.0.1",
     description="Razorpay Python Client",
     long_description=readme_content,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## 2.0.1 - 2026-03-09
- feat: Added Support for [cancel token](https://razorpay.com/docs/api/payments/recurring-payments/upi/tokens/#24-cancel-token)
