### PR TITLE
update python matrix

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,12 +17,16 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.10, 3.11, 3.12, 3.13, 3,14]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
+
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         pip install setuptools

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10, 3.11, 3.12, 3.13, 3,14]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
As mentioned on https://github.com/razorpay/razorpay-python/pull/265 the current CI is running on last python, and not using the matrix.
The matrix is using very old versions of Python, change to the current supported Python versions (removed EOL)
The CI is using old versions of requires-python and checkout, changed to the last versions