### PR TITLE
ci: update GitHub Actions checkout and setup-python to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"  
       - name: Install dependencies
@@ -36,9 +36,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -59,14 +59,14 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist      
       - name: Set up Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Publish packages to PyPi


### PR DESCRIPTION
## CI: Update GitHub Actions to latest versions

GitHub Actions `actions/checkout` and `actions/setup-python` have newer versions
with bug fixes, performance improvements, and Node.js compatibility updates:

- `actions/checkout@v3` → `@v4` (Node.js 20, improved performance)
- `actions/setup-python@v3`/`v4` → `@v5` (Node.js 20, improved caching)

**Files updated:**
  - `.github/workflows/ci.yml`: checkout: 3 occurrence(s), setup-python: 3 occurrence(s)

**Why this matters:**
- Node.js 16 (used by older action versions) is EOL since September 2024
- GitHub emits deprecation warnings for v3 and older actions in CI logs
- v4/v5 are functionally equivalent drop-in replacements
