### PR TITLE
chore: add servicetree.yaml manifest

### DIFF
--- a/servicetree.yaml
+++ b/servicetree.yaml
@@ -1,0 +1,37 @@
+service: razorpay-python  # required, canonical slug — immutable once registered
+displayName: "Razorpay Python SDK"  # human-readable name — README title "Razorpay Python Client"; published on PyPI as the `razorpay` package
+description: "Official Python bindings for the Razorpay API — the merchant-facing SDK (pip install razorpay) for programmatic payments, orders, refunds and the rest of the API surface."  # README: "Python bindings for interacting with the Razorpay API. This is primarily meant for merchants who wish to perform interactions with the Razorpay API programatically"; PyPI badge, setup.py, razorpay/ package, tests/
+type: library  # a merchant-facing client SDK published to PyPI — no server component · retype after the serviceTypes enum widens: sdk
+tier: T1  # customer-facing: one of the primary public SDKs merchants integrate against the live API — a broken release degrades merchant integrations org-wide; T1 per the brief's customer-facing definition
+lifecycle: live  # published and versioned on PyPI with a maintained CHANGELOG; pushed 2026-08-28
+
+domain: razorpay1/partnerships  # l1 family razorpay1 from miss_seed (BU SME Payments, team Partnerships — csv_group "PG (Plugins, Checkout)"); area partnerships, which is where the public SDKs/plugins sit in this family
+
+owner:
+  team:  # required, owning team slug — TO FILL: this repo has no CODEOWNERS file, .github/repo_owners.json carries no team slug, and the GitHub repository-teams API is not readable with the current token; ask the POD lead for the owning GitHub team
+  em:  # name | @slack | email — TO FILL: DevRev runnable owner not found in SuccessFactors
+  org_group:  # SuccessFactors group of the EM — TO FILL: the declared owner has no SuccessFactors record, so the org tree cannot be resolved; ask the POD lead
+  org_sub_group:  # SuccessFactors sub-group of the EM — TO FILL: the declared owner has no SuccessFactors record; ask the POD lead
+  org_pod:  # SuccessFactors pod of the EM — TO FILL: the declared owner has no SuccessFactors record; ask the POD lead
+  pm:  # TO FILL: ask the Partnerships POD lead who product-owns the public SDKs
+  overrides: []  # optional, region-scoped owner overrides — TO FILL only if some region is owned by a different team; each entry is a "region" code plus the owning "team" slug
+
+links:
+  repo: "https://github.com/razorpay/razorpay-python"  # canonical GitHub repo URL
+  alerts_repo:  # this service's alert rules in razorpay/alert-rules — TO FILL: no matching ruleset found; add one in razorpay/alert-rules, then link the file here
+  slos:  # SLO definitions — TO FILL: no slo.yaml at this repo root and no sloth ruleset for it under razorpay/alert-rules/slo/prod (the two places SLOs are defined today); add one there and link it here
+  slack_channel:  # TO FILL: no Slack channel found — draft harvested zero candidates; the public-SDK channels used by sibling SDKs are not verifiable for this repo from harvested sources. Ask the Partnerships POD lead which channel owns the public SDKs
+  zenduty_policy:  # Zenduty policy/service name used for paging — TO FILL: the service-to-policy mapping is not in DevRev or alert-rules for this service; it lives in the external Zenduty policies sheet
+  escalation_l1:  # service EM — TO FILL: no owner could be resolved for this service
+  escalation_l2:  # EM's manager — TO FILL: the EM has no SuccessFactors record, so no manager chain is available
+  escalation_l3:  # manager's manager — TO FILL: the EM has no SuccessFactors record, so no manager chain is available
+  oncall_handle:  # Slack/PagerDuty oncall handle or usergroup — TO FILL: not set on the DevRev runnable
+  runbook:  # link to the incident runbook — TO FILL: no runbook directory for this service in razorpay/rzp-oncall-agent; add one or link the Google Doc / alpha.razorpay.com page
+  api_docs: "https://pypi.org/project/razorpay/"  # the package's published documentation home (PyPI project page, linked from the README badges) — the SDK's API docs are the Razorpay API reference plus PyPI usage docs
+  dashboard:  # primary dashboard — TO FILL: Grafana (vajra) / Coralogix dashboard URL for this service (see per-region links below)
+  logs_and_traces: "https://razorpay-prod.app.coralogix.in/#/query-new/archive-logs"  # org-standard prod Coralogix — filter subsystem "razorpay-python"
+  strategy_okr:  # TO FILL: link the FY strategy doc for the owning group.
+  risk_assessment:  # TO FILL: no .agents/skills/risk-assessment in this repo; add the per-repo risk-assessment skill
+  regions:  # per-region links — TO FILL: no prod region deployment found for this service in spinacode or alert-rules; add a block per geography once it ships
+
+dependencies: []  # optional, declared service dependencies — TO FILL: shape: - service: <slug> for internal deps, - vendor: <name> for external (gateways, banks)


### PR DESCRIPTION
Adds the Service Tree manifest (`servicetree.yaml`) to the repo root.

This manifest declares service ownership, tier, domain, and links for the Service Tree registry. Fields not yet sourced are left blank with inline comments.

Part of the Service Tree rollout.

Generated with Claude Code